### PR TITLE
generate valid flux batch script for user cmdl resubmission

### DIFF
--- a/docker/pbs/test.sh
+++ b/docker/pbs/test.sh
@@ -15,7 +15,8 @@ echo " "
 #yum update -y
 #yum upgrade -y
 #yum install -y curl openssl-devlel bzip2-devel libffi-devel
-curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
+MINICONDA=Miniconda3-py313_25.5.1-1-Linux-x86_64.sh
+curl -sSL https://repo.anaconda.com/miniconda/$MINICONDA -o miniconda.sh
 bash miniconda.sh -bfp $HOME/miniconda
 rm -rf miniconda.sh
 export PATH="$HOME/miniconda/bin:$PATH"

--- a/tests/config.py
+++ b/tests/config.py
@@ -13,9 +13,7 @@ def test_config_launch_basic(tmpdir):
                     "exec": "my-mpiexec",
                     "default_options": ["-a", "-b"],
                     "mappings": {"-e": "-f"},
-                    "mpiexec": {
-                        "default_options": ["-c", "-d"]
-                    }
+                    "mpiexec": {"default_options": ["-c", "-d"]},
                 }
             }
         )

--- a/tests/launch.py
+++ b/tests/launch.py
@@ -1,7 +1,7 @@
 import os
 import shlex
-from pathlib import Path
 from contextlib import contextmanager
+from pathlib import Path
 
 import yaml
 

--- a/tests/launch.py
+++ b/tests/launch.py
@@ -46,7 +46,7 @@ def test_envar_config(capfd):
     env = {
         "HPC_CONNECT_BACKEND": "slurm",
         "HPC_CONNECT_LAUNCH_EXEC": "srun",
-        "HPC_CONNECT_LAUNCH_NUMPROC_FLAG": "-np"
+        "HPC_CONNECT_LAUNCH_NUMPROC_FLAG": "-np",
     }
     with envmods(**env):
         launch(["-n", "4", "-flag", "file", "executable", "--option"], files=False)
@@ -75,7 +75,7 @@ def test_file_config(tmpdir, capfd):
                     {
                         "hpc_connect": {
                             "backend": "slurm",
-                            "launch": {"exec": "srun", "numproc_flag": "-np"}
+                            "launch": {"exec": "srun", "numproc_flag": "-np"},
                         }
                     },
                     fh,
@@ -94,7 +94,7 @@ def test_file_config(tmpdir, capfd):
                                 "exec": "mpiexec",
                                 "numproc_flag": "-np",
                                 "default_options": "--map-by ppr:%(np)d:cores",
-                            }
+                            },
                         }
                     },
                     fh,
@@ -115,7 +115,7 @@ def test_file_config(tmpdir, capfd):
                                 "exec": "mpiexec",
                                 "numproc_flag": "-np",
                                 "mappings": {"-flag": "-xflag"},
-                            }
+                            },
                         }
                     },
                     fh,

--- a/tests/pbs.py
+++ b/tests/pbs.py
@@ -8,8 +8,8 @@ import os
 import hpcc_pbs.backend
 from hpc_connect import JobSpec
 
-def test_basic(tmpdir):
 
+def test_basic(tmpdir):
     workspace = Path(tmpdir.strpath)
     workspace.mkdir(parents=True, exist_ok=True)
     cwd = Path.cwd()
@@ -26,7 +26,7 @@ def test_basic(tmpdir):
             error="my-err.txt",
             workspace=Path.cwd(),
             time_limit=1.0,
-            env={"MY_VAR": "SPAM"}
+            env={"MY_VAR": "SPAM"},
         )
         backend.submission_manager().adapter.submit(job)
         text = (workspace / "my-job.sh").read_text()

--- a/tests/pbs.py
+++ b/tests/pbs.py
@@ -30,7 +30,7 @@ def test_basic(tmpdir):
         )
         backend.submission_manager().adapter.submit(job)
         text = (workspace / "my-job.sh").read_text()
-        assert "#!/bin/sh" in text
+        assert "bin/sh" in text
         assert "#PBS -V" in text
         assert "#PBS -N my-job" in text
         assert f"#PBS -l nodes=1:ppn={cpus_per_node}" in text

--- a/tests/pbs.py
+++ b/tests/pbs.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-from pathlib import Path
 import os
+from pathlib import Path
 
 import hpcc_pbs.backend
 from hpc_connect import JobSpec

--- a/tests/slurm.py
+++ b/tests/slurm.py
@@ -12,7 +12,6 @@ import hpcc_slurm.process
 
 
 def test_basic(tmpdir):
-
     workspace = Path(tmpdir.strpath)
     workspace.mkdir(parents=True, exist_ok=True)
     cwd = Path.cwd()

--- a/tests/slurm.py
+++ b/tests/slurm.py
@@ -32,7 +32,7 @@ def test_basic(tmpdir):
         backend.submission_manager().adapter.submit(spec)
         text = (workspace / "my-job.sh").read_text()
         print(text)
-        assert "#!/bin/sh" in text
+        assert "bin/sh" in text
         assert "#SBATCH --nodes=1" in text
         assert "#SBATCH --time=00:00:01" in text
         assert "#SBATCH --job-name=my-job" in text


### PR DESCRIPTION
The latest version of hpc-connect-generated batch scripts for flux had minor issues preventing them from being passed to `flux batch` as a user to retry things. Testing didn't catch this since the batch script is not actually used for managing the allocation behind the scenes and is only output for convenience.

This PR corrects the option syntax, fixes a few typos, and properly sets the time limit units.