### PR TITLE
Add support for gres output with socket affinity.

### DIFF
--- a/src/hpcc_slurm/discover.py
+++ b/src/hpcc_slurm/discover.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -26,7 +27,9 @@ def read_sinfo() -> dict[str, Any] | None:
         format = " ".join(opts)
         args = [sinfo, "-o", format]
         try:
-            proc = subprocess.run(args, check=True, encoding="utf-8", capture_output=True)
+            proc = subprocess.run(
+                args, check=True, encoding="utf-8", capture_output=True
+            )
         except subprocess.CalledProcessError:
             return None
         else:
@@ -96,9 +99,32 @@ def read_sinfo() -> dict[str, Any] | None:
 def safe_loads(arg: str) -> Any:
     if arg == "(null)":
         return None
+    if ":" in arg:
+        arg = strip_gres_suffixes(arg)
     if arg.endswith("+"):
         return safe_loads(arg[:-1])
     try:
         return json.loads(arg)
     except json.JSONDecodeError:
         return arg
+
+
+def strip_gres_suffix(gres: str) -> str:
+    """Remove trailing socket affinity patterns like (S:0-1) from GRES strings.
+
+    Examples:
+        "gpu:a40:1(S:0-1)" -> "gpu:a40:1"
+        "nic:mlx5:1(S:0)" -> "nic:mlx5:1"
+        "mem:128G(S:0-3)" -> "mem:128G"
+        "gpu:h100:4" -> "gpu:h100:4" (no change)
+    """
+    return re.sub(r"\s*\([^)]*\)\s*$", "", gres)
+
+
+def strip_gres_suffixes(gres_field: str) -> str:
+    """Handle comma-separated GRES fields, stripping suffixes from each.
+
+    Examples:
+        "gpu:a40:1(S:0-1),nic:mlx5:1(S:0)" -> "gpu:a40:1,nic:mlx5:1"
+    """
+    return ",".join(strip_gres_suffix(x.strip()) for x in gres_field.split(","))

--- a/tests/test_hpcc_slurm_discover.py
+++ b/tests/test_hpcc_slurm_discover.py
@@ -1,0 +1,114 @@
+import pytest
+from types import SimpleNamespace
+
+from hpcc_slurm.discover import (
+    read_sinfo,
+    strip_gres_suffix,
+    strip_gres_suffixes,
+    safe_loads,
+)
+
+
+def test_read_sinfo_parses_first_data_line(monkeypatch):
+    fake_stdout = """SOCKETS CORES THREADS CPUS NODES GRES
+2 64 1 128 16 gpu:a40:1(S:0-1)
+2 64 1 128 32 gpu:100:4(S:0-1)
+2 16+ 1 32+ 1445 (null)
+"""
+
+    def mock_which(cmd):
+        assert cmd == "sinfo"
+        return "/usr/bin/sinfo"
+
+    def mock_run(args, check, encoding, capture_output):
+        assert args == ["/usr/bin/sinfo", "-o", "%X %Y %Z %c %D %G"]
+        assert check is True
+        assert encoding == "utf-8"
+        assert capture_output is True
+        return SimpleNamespace(stdout=fake_stdout)
+
+    monkeypatch.setattr("hpcc_slurm.discover.shutil.which", mock_which)
+    monkeypatch.setattr("hpcc_slurm.discover.subprocess.run", mock_run)
+
+    result = read_sinfo()
+
+    assert result == {
+        "type": "node",
+        "count": 16,
+        "resources": [
+            {
+                "type": "socket",
+                "count": 2,
+                "resources": [
+                    {
+                        "type": "cpu",
+                        "count": 64,
+                    },
+                ],
+            },
+            {
+                "type": "gpu",
+                "count": 1,
+                "gres": "a40",
+            },
+        ],
+        "additional_properties": {
+            "/usr/bin/sinfo -o '%X %Y %Z %c %D %G'": "2 64 1 128 16 gpu:a40:1(S:0-1)",
+            "sockets_per_node": 2,
+            "cores_per_socket": 64,
+            "threads_per_core": 1,
+            "cpus_per_node": 128,
+            "gres": "gpu:a40:1",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "token,expected",
+    [
+        ("(null)", None),
+        ("112", 112),
+        ("32+", 32),
+        ("gpu:h100:4", "gpu:h100:4"),
+        ("gpu:a40:1(S:0-1)", "gpu:a40:1"),
+    ],
+)
+def test_safe_loads(token, expected):
+    assert safe_loads(token) == expected
+
+
+@pytest.mark.parametrize(
+    "gres_field,expected",
+    [
+        ("gpu:a40:1(S:0-1),nic:mlx5:1(S:0)", "gpu:a40:1,nic:mlx5:1"),
+        ("gpu:h100:4, nic:mlx5:2(S:0)", "gpu:h100:4,nic:mlx5:2"),
+    ],
+)
+def test_strip_gres_suffixes(gres_field, expected):
+    assert strip_gres_suffixes(gres_field) == expected
+
+
+@pytest.mark.parametrize(
+    "gres,expected",
+    [
+        ("gpu:a40:1(S:0-1)", "gpu:a40:1"),
+        ("gpu:a40:1(S:0-1,3-5)", "gpu:a40:1"),
+        ("nic:mlx5:1(S:0)", "nic:mlx5:1"),
+        ("mem:128G(S:0-3)", "mem:128G"),
+        ("fpga:2(S:0-1)", "fpga:2"),
+    ],
+)
+def test_strip_gres_suffix_affinity(gres, expected):
+    assert strip_gres_suffix(gres) == expected
+
+
+@pytest.mark.parametrize(
+    "gres",
+    [
+        "gpu:h100:4",
+        "nic:mlx5:2",
+        "mem:64G",
+    ],
+)
+def test_strip_gres_suffix_no_affinity(gres):
+    assert strip_gres_suffix(gres) == gres


### PR DESCRIPTION
The SLURM Generic RESource (GRES) management specification `man gres.conf` supports specifications for the sockets that a resource can run on.  In my case I have the following output from `sinfo -o "%X %Y %Z %c %D %G"`
```
SOCKETS CORES THREADS CPUS NODES GRES
2 64 1 128 16 gpu:a40:1(S:0-1)
2 64 1 128 32 gpu:100:4(S:0-1)
2 16+ 1 32+ 1445 (null)
```
The changes in this merge request allow hpc-connect to correctly parse the gres specification by ignoring the socket affinity.