### PR TITLE
fix the job.cancel() impelementation for Flux

### DIFF
--- a/docker/flux/test.sh
+++ b/docker/flux/test.sh
@@ -33,8 +33,10 @@ echo " "
 exit_code=0
 canary -d run --show-excluded-tests -w -b scheduler=flux ./examples || exit_code=$?
 if [ "${exit_code}" -ne 14 ]; then
-  cat .canary/config || true
-  cat .canary/cache/hpc-connect/*/*/canary-out.txt || true
+  cat .canary/cache/canary-hpc/batches/*/resource_pool.json || true
+  cat .canary/cache/canary-hpc/batches/*/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-err.txt || true
   exit 1
 fi
 
@@ -43,40 +45,15 @@ echo "------------------------Test 2----------------------"
 echo " "
 # Test 2
 exit_code=0
-canary -d run --show-excluded-tests -w -b scheduler=flux -b spec=count:3 ./examples || exit_code=$?
+canary -d run --show-excluded-tests -w -b scheduler=flux -b spec=count:3,nodes:any ./examples || exit_code=$?
 if [ "${exit_code}" -ne 14 ]; then
-  cat .canary/config || true
-  cat .canary/cache/hpc-connect/*/*/canary-out.txt || true
-  exit 1
-fi
-
-echo " "
-echo "------------------------Test 3----------------------"
-echo " "
-# Test 3
-exit_code=0
-canary -d run --show-excluded-tests -w -b scheduler=flux -b spec=count:3,layout:atomic ./examples || exit_code=$?
-if [ "${exit_code}" -ne 14 ]; then
-  cat .canary/config || true
-  cat .canary/cache/hpc-connect/*/*/canary-out.txt || true
-  exit 1
-fi
-
-echo " "
-echo "------------------------Test 4----------------------"
-echo " "
-# Test 4
-exit_code=0
-canary -d run --show-excluded-tests -w -b scheduler=flux -b spec=count:auto,layout:flat ./examples || exit_code=$?
-if [ "${exit_code}" -ne 14 ]; then
-  cat .canary/config || true
-  cat .canary/cache/hpc-connect/*/*/canary-out.txt || true
+  cat .canary/cache/canary-hpc/batches/*/resource_pool.json || true
+  cat .canary/cache/canary-hpc/batches/*/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-err.txt || true
   exit 1
 fi
 
 echo " "
 echo " "
 echo "----------------------- Done! ----------------------"
-# Artifacts
-canary report junit create -o $CI_PROJECT_DIR/junit.xml || true
-canary report cdash create -d $CI_PROJECT_DIR/xml || true

--- a/docker/slurm/test.sh
+++ b/docker/slurm/test.sh
@@ -17,8 +17,10 @@ echo " "
 exit_code=0
 canary -d run --show-excluded-tests -w -b scheduler=slurm ./examples || exit_code=$?
 if [ "${exit_code}" -ne 14 ]; then
-  cat .canary/config || true
-  cat .canary/cache/canary-hpc/*/*/canary-out.txt || true
+  cat .canary/cache/canary-hpc/batches/*/resource_pool.json || true
+  cat .canary/cache/canary-hpc/batches/*/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-err.txt || true
   exit 1
 fi
 
@@ -27,10 +29,12 @@ echo "------------------------Test 2----------------------"
 echo " "
 # Test 2
 exit_code=0
-canary -d run --show-excluded-tests -w -b scheduler=slurm -b spec=count:3 ./examples || exit_code=$?
+canary -d run --show-excluded-tests -w -b scheduler=slurm -b spec=count:3,nodes:any ./examples || exit_code=$?
 if [ "${exit_code}" -ne 14 ]; then
-  cat .canary/config || true
-  cat .canary/cache/canary-hpc/*/*/canary-out.txt || true
+  cat .canary/cache/canary-hpc/batches/*/resource_pool.json || true
+  cat .canary/cache/canary-hpc/batches/*/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-err.txt || true
   exit 1
 fi
 
@@ -39,10 +43,12 @@ echo "------------------------Test 3----------------------"
 echo " "
 # Test 3
 exit_code=0
-canary -d run --show-excluded-tests -w -b scheduler=slurm -b spec=count:3,layout:atomic ./examples || exit_code=$?
+canary -d run --show-excluded-tests -w -b scheduler=slurm -b spec=count:3,layout:atomic,nodes:any ./examples || exit_code=$?
 if [ "${exit_code}" -ne 14 ]; then
-  cat .canary/config || true
-  cat .canary/cache/canary-hpc/*/*/canary-out.txt || true
+  cat .canary/cache/canary-hpc/batches/*/resource_pool.json || true
+  cat .canary/cache/canary-hpc/batches/*/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-err.txt || true
   exit 1
 fi
 
@@ -51,9 +57,12 @@ echo "------------------------Test 4----------------------"
 echo " "
 # Test 4
 exit_code=0
-canary -d run --show-excluded-tests -w -b scheduler=slurm -b spec=count:auto,layout:flat ./examples || exit_code=$?
+canary -d run --show-excluded-tests -w -b scheduler=slurm -b spec=count:auto,layout:flat,nodes:any ./examples || exit_code=$?
 if [ "${exit_code}" -ne 14 ]; then
-  cat .canary/cache/canary-hpc/*/*/canary-out.txt || true
+  cat .canary/cache/canary-hpc/batches/*/resource_pool.json || true
+  cat .canary/cache/canary-hpc/batches/*/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-out.txt || true
+  cat TestResults/basic/second/second/canary-err.txt || true
   exit 1
 fi
 
@@ -61,6 +70,3 @@ fi
 echo " "
 echo " "
 echo "----------------------- Done! ----------------------"
-# Artifacts
-canary report junit create -o $CI_PROJECT_DIR/junit.xml || true
-canary report cdash create -d $CI_PROJECT_DIR/xml || true

--- a/src/hpc_connect/__init__.py
+++ b/src/hpc_connect/__init__.py
@@ -16,6 +16,7 @@ from .launch import HPCLauncher
 from .launch import LaunchAdapter
 from .process import HPCProcess
 from .submit import HPCSubmissionManager
+from .submit import SubmissionFailedError
 
 __all__ = [
     "Backend",
@@ -29,6 +30,7 @@ __all__ = [
     "HPCProcess",
     "HPCSubmissionManager",
     "JobSpec",
+    "SubmissionFailedError",
 ]
 
 if os.getenv("HPC_CONNECT_DEBUG", "no").lower() in ("yes", "true", "1", "on"):

--- a/src/hpc_connect/submit.py
+++ b/src/hpc_connect/submit.py
@@ -8,6 +8,10 @@ from .jobspec import JobSpec
 from .process import HPCProcess
 
 
+class SubmissionFailedError(Exception):
+    pass
+
+
 class Adapter(Protocol):
     def submit(self, spec: JobSpec, exclusive: bool = False) -> HPCProcess: ...
     def polling_interval(self) -> float: ...

--- a/src/hpcc_flux/backend.py
+++ b/src/hpcc_flux/backend.py
@@ -101,7 +101,7 @@ class FluxAdapter:
     def submit(self, spec: hpc_connect.JobSpec, exclusive: bool = True) -> FluxProcess:
         jobspec = self.prepare(spec, exclusive=exclusive)
         fut = self.backend.flux.submit(jobspec)  # type: ignore
-        return FluxProcess(spec.name, future=fut)
+        return FluxProcess(spec.name, future=fut, fh=self.backend.fh)
 
     def prepare(self, spec: hpc_connect.JobSpec, exclusive: bool = True) -> Jobspec:
         duration = int(spec.time_limit + 60)

--- a/src/hpcc_flux/process.py
+++ b/src/hpcc_flux/process.py
@@ -20,8 +20,8 @@ logger = logging.getLogger("hpc_connect.flux.submit")
 class FluxProcess(hpc_connect.HPCProcess):
     JOB_TIMEOUT_CODE = 66
 
-    def __init__(self, name: str, future: FluxExecutorFuture) -> None:
-        self.fh = Flux()
+    def __init__(self, name: str, future: FluxExecutorFuture, fh: Flux) -> None:
+        self.fh = fh
         self.name = name
         self.fut: FluxExecutorFuture = future
         self._rc: int | None = None

--- a/src/hpcc_flux/process.py
+++ b/src/hpcc_flux/process.py
@@ -39,11 +39,8 @@ class FluxProcess(hpc_connect.HPCProcess):
                 self.flux_jobid = fut.jobid()
                 self.jobid = str(self.flux_jobid)
                 logger.debug(f"submitted job {self.jobid} for {self.name}")
-            except CancelledError:
+            except (CancelledError, Exception):
                 self.returncode = 1
-            except Exception as e:
-                logger.exception("Submission failed")
-                raise
 
         def set_submittime(fut: FluxExecutorFuture, *args):
             self.submitted = time.time()

--- a/src/hpcc_flux/process.py
+++ b/src/hpcc_flux/process.py
@@ -25,6 +25,7 @@ class FluxProcess(hpc_connect.HPCProcess):
         self.name = name
         self.fut: FluxExecutorFuture = future
         self._rc: int | None = None
+        self.flux_jobid: flux.job.JobID | None = None
 
         def set_returncode(fut: FluxExecutorFuture):
             try:
@@ -35,7 +36,8 @@ class FluxProcess(hpc_connect.HPCProcess):
 
         def set_jobid(fut: FluxExecutorFuture):
             try:
-                self.jobid = str(fut.jobid())
+                self.flux_jobid = fut.jobid()
+                self.jobid = str(self.flux_jobid)
                 logger.debug(f"submitted job {self.jobid} for {self.name}")
             except CancelledError:
                 self.returncode = 1
@@ -68,7 +70,7 @@ class FluxProcess(hpc_connect.HPCProcess):
     def cancel(self) -> None:
         logger.warning(f"Canceling flux job {self.jobid}")
         try:
-            flux.job.cancel(self.fh, int(self.jobid))
+            flux.job.cancel(self.fh, self.flux_jobid)
         except OSError:
             logger.debug(f"Job {self.jobid} is inactive, cannot cancel")
         except Exception:

--- a/src/hpcc_pbs/process.py
+++ b/src/hpcc_pbs/process.py
@@ -46,7 +46,7 @@ class PBSProcess(hpc_connect.HPCProcess):
         with open(script) as fh:
             script_lines = fh.read()
         logger.error(f"    qsub script: {script_lines}")
-        raise SubmissionFailedError
+        raise hpc_connect.SubmissionFailedError
 
     @property
     def returncode(self) -> int | None:
@@ -91,7 +91,3 @@ class PBSProcess(hpc_connect.HPCProcess):
         if qdel is None:
             raise RuntimeError("qdel not found on PATH")
         self.returncode = 1
-
-
-class SubmissionFailedError(Exception):
-    pass

--- a/src/hpcc_slurm/process.py
+++ b/src/hpcc_slurm/process.py
@@ -52,7 +52,7 @@ class SlurmProcess(hpc_connect.HPCProcess):
             logger.log(logging.ERROR, f"    {line}")
         for line in proc.stderr.split("\n"):
             logger.log(logging.ERROR, f"    {line}")
-        raise SubmissionFailedError
+        raise hpc_connect.SubmissionFailedError
 
     @staticmethod
     def parse_script_args(script: str) -> argparse.Namespace:
@@ -135,7 +135,3 @@ class SlurmProcess(hpc_connect.HPCProcess):
         logger.warning(f"cancelling slurm job {self.jobid}")
         subprocess.run(["scancel", self.jobid, "--clusters=all"])
         self.returncode = 1
-
-
-class SubmissionFailedError(Exception):
-    pass

--- a/tests/config.py
+++ b/tests/config.py
@@ -14,7 +14,7 @@ def test_config_launch_basic(tmpdir):
             "launch": {
                 "type": "mpi",
                 "default_options": ["-a", "-b"],
-            }
+            },
         }
         config.set("backends", [backend_cfg])
         backend = config.backend("my-backend")

--- a/tests/launch.py
+++ b/tests/launch.py
@@ -1,13 +1,8 @@
-import os
 from contextlib import contextmanager
-from pathlib import Path
-
-import yaml
-
 import hpc_connect
-
-
+from pathlib import Path
 import pytest
+import os
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/launch.py
+++ b/tests/launch.py
@@ -1,8 +1,10 @@
-from contextlib import contextmanager
-import hpc_connect
-from pathlib import Path
-import pytest
 import os
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+import hpc_connect
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/launch.py
+++ b/tests/launch.py
@@ -9,6 +9,7 @@ import hpc_connect
 
 import pytest
 
+
 @pytest.fixture(scope="function", autouse=True)
 def reset_config():
     hpc_connect.config.reset()
@@ -92,6 +93,7 @@ def test_file_config_2(tmpdir, capfd):
             assert (
                 out == f"{mock_bin}/mpiexec --map-by ppr:4:cores -np 4 -flag file executable --option"
             )
+
 
 def test_file_config_3(tmpdir, capfd):
     workspace = Path(tmpdir.strpath)

--- a/tests/test_hpcc_slurm_discover.py
+++ b/tests/test_hpcc_slurm_discover.py
@@ -1,12 +1,11 @@
-import pytest
-from types import SimpleNamespace
-
 from hpcc_slurm.discover import (
     read_sinfo,
     strip_gres_suffix,
     strip_gres_suffixes,
     safe_loads,
 )
+import pytest
+from types import SimpleNamespace
 
 
 def test_read_sinfo_parses_first_data_line(monkeypatch):

--- a/tests/test_hpcc_slurm_discover.py
+++ b/tests/test_hpcc_slurm_discover.py
@@ -1,11 +1,11 @@
-from hpcc_slurm.discover import (
-    read_sinfo,
-    strip_gres_suffix,
-    strip_gres_suffixes,
-    safe_loads,
-)
-import pytest
 from types import SimpleNamespace
+
+import pytest
+
+from hpcc_slurm.discover import read_sinfo
+from hpcc_slurm.discover import safe_loads
+from hpcc_slurm.discover import strip_gres_suffix
+from hpcc_slurm.discover import strip_gres_suffixes
 
 
 def test_read_sinfo_parses_first_data_line(monkeypatch):


### PR DESCRIPTION
according to the [docs](https://flux-framework.readthedocs.io/projects/flux-core/en/latest/python/autogenerated/flux.job.kill.html#flux.job.kill.cancel) the API takes an integer or JobID. For most installations if Flux, the JobID is *not* an integer and the string representation is not convertible to an integer! Thus we were always throwing an exception before even calling through to the API.

This change stores off the Flux JobID as well as the string representation and ensures that calls to Flux APIs use the `flux_jobid` instead of the `jobid`.